### PR TITLE
fix online_packing and add channel_loss

### DIFF
--- a/megatron_patch/arguments.py
+++ b/megatron_patch/arguments.py
@@ -619,6 +619,9 @@ def get_patch_args(parser):
     group.add_argument('--online-packing',
                     action='store_true',
                     help='If set, dataloader tokenize and packing datasets online')
+    group.add_argument('--calc-channel-loss',
+                    action='store_true',
+                    help='If set, calculate loss group by channel')
     group.add_argument('--te-spec-version',
                     type=str,
                     choices=["base", "tqlm"],

--- a/megatron_patch/data/__init__.py
+++ b/megatron_patch/data/__init__.py
@@ -103,7 +103,7 @@ def build_dataset(args, train_val_test_num_samples):
         BlendedMegatronDatasetBuilder,
     )
     if args.online_packing:
-        ds = datasets.load_dataset('text', data_files=args.train_data_path or args.data_path, split='train')
+        ds = datasets.load_dataset('json', data_files=args.train_data_path or args.data_path, split='train')
         return ds, ds, ds
     if get_tokenizer() is None:
         build_tokenizer(args)

--- a/megatron_patch/data/collator.py
+++ b/megatron_patch/data/collator.py
@@ -1,49 +1,66 @@
 import json
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 from dataclasses import dataclass
-from transformers.tokenization_utils_base import PreTrainedTokenizerBase
-
-@dataclass
-class DataCollatorForSFTRawText:
-
-    tokenizer: PreTrainedTokenizerBase
-    max_padding_length: int = 4096
-
-    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
-        input_ids = []
-        labels = []
-        position_ids = []
-        for feature in features:
-            text = json.loads(feature['text'])['messages']
-            source = self.tokenizer.apply_chat_template(text[:-1])
-            full = self.tokenizer.apply_chat_template(text)
-            if len(full) >= self.max_padding_length:
-                continue
-
-            full = full + [self.tokenizer.pad_token_id]
-            label = [self.tokenizer.pad_token_id] * len(source) + full[len(source):]
-
-            input_ids.append(full[:-1])
-            labels.append(label[1:])
-            position_ids.append(list(range(len(full)-1)))
-
-        return dict(input_ids=input_ids, labels=labels, position_ids=position_ids)
+from megatron.core.datasets.megatron_tokenizer import MegatronTokenizer
+from .types import CPTMessage, SFTMessage
 
 @dataclass
 class DataCollatorForCPTRawText:
 
-    tokenizer: PreTrainedTokenizerBase
+    tokenizer: MegatronTokenizer
 
-    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def __call__(self, features: List[Dict[str, Any]]) -> CPTMessage:
+        tokens = []
+        channels = []
+        for feature in features:
+            text = feature['text']
+            sentence_ids = self.tokenizer.tokenizer(text, add_special_tokens=False)['input_ids']
+            if not sentence_ids:
+                print(f"tokenizer error sentence_ids is empty :\n {text} \n")
+                continue
+            if max(sentence_ids) >= self.tokenizer.vocab_size:
+                print(f"tokenizer error max(sentence_ids) >= Encoder.tokenizer.vocab_size :\n {text}\n {max(sentence_ids)}")
+                continue
+            sentence_ids.append(self.tokenizer.eod)
+            tokens.append(sentence_ids)
+            channel = feature['channel'] if 'channel' in feature else ''
+            channels.append(channel)
+
+        return CPTMessage(
+            tokens = tokens,
+            channels = channels
+        )
+
+
+@dataclass
+class DataCollatorForSFTRawText:
+
+    tokenizer: MegatronTokenizer
+    max_padding_length: int = 32768
+
+    def __call__(self, features: List[Dict[str, Any]]) -> SFTMessage:
         input_ids = []
         labels = []
-        position_ids = []
+        channels = []
         for feature in features:
-            text = json.loads(feature['text'])['text']
-            tokens = self.tokenizer(text, add_special_tokens=False)['input_ids']
-            tokens = tokens + [self.tokenizer.pad_token_id]
+            text = feature['messages']
+            source = self.tokenizer.apply_chat_template(text[:-1])
+            full = self.tokenizer.apply_chat_template(text)
+            if len(full) >= self.max_padding_length:
+                continue
+            for t1, t2 in zip(source, full):
+                assert t1 == t2, "The user input_ids are not a prefix of the full input_ids!"
 
-            input_ids.append(tokens[:-1])
-            labels.append(tokens[1:])
+            label = [self.tokenizer.pad_token_id] * (len(source)-1) + full[len(source):] + [self.tokenizer.pad_token_id]
+            full[-1] = -1 - full[-1]
 
-        return dict(input_ids=input_ids, labels=labels)
+            input_ids.append(full)
+            labels.append(label)
+            channel = feature['channel'] if 'channel' in feature else ''
+            channels.append(channel)
+
+        return SFTMessage(
+            input_ids = input_ids,
+            labels = labels,
+            channels = channels
+        )

--- a/megatron_patch/data/concator.py
+++ b/megatron_patch/data/concator.py
@@ -1,86 +1,104 @@
 from dataclasses import dataclass
-from typing import List, Dict, Any
-
-# ensure all the keys in data have the same batch_size and seqlen
-def data_validation(data: Dict[str, List[Any]]):
-    keys = list(data.keys())
-    pkey = keys[0]
-    keys = keys[1:]
-    pseq_list = []
-    for batch in data[pkey]:
-        pseq_list.append(len(batch))
-    for key in keys:
-        batches = data[key]
-        assert len(batches) == len(pseq_list), f"different batchsize: {pkey}: {len(pseq_list)}, {key}: {len(batches)}"
-        seq_list = [len(batch) for batch in batches]
-        assert not any([x-y for x, y in zip(pseq_list, seq_list)]), f"different seqlen: {pkey}: {pseq_list}, {key}: {seq_list}"
+from typing import List, Tuple, Deque, Dict, Optional
+from collections import deque
+from .types import CPTMessage, SFTMessage, CPTConcatedMessage, SFTConcatedMessage
 
 @dataclass
 class CPTConcatFn:
     batch_size: int
     max_seqlen: int
+    pad_token_id: int
+    concated: Optional[Dict[str, Deque]] = None
 
-    def __call__(self, data_concating: Dict[str, List[Any]], data: Dict[str, List[Any]]):
-        # data_validation(data)
-        result = {}
-        for key in data:
-            assert key in ("input_ids", "labels")
-            value = data[key]
-            bs = len(value)
-            for b in range(bs):
-                if len(data_concating[key]) == 0:
-                    data_concating[key].append([])
-                data_concating[key][-1] += value[b]
-                while(len(data_concating[key][-1])) > self.max_seqlen:
-                    prev_seqs = data_concating[key][-1]
-                    next_seqs = prev_seqs[self.max_seqlen:]
-                    prev_seqs = prev_seqs[:self.max_seqlen]
-                    data_concating[key][-1] = prev_seqs
-                    data_concating[key].append(next_seqs)
-            concated_bs = len(data_concating[key])
-            if concated_bs > self.batch_size:
-                result[key] = data_concating[key][:self.batch_size]
-                data_concating[key] = data_concating[key][self.batch_size:]
-        if len(result) == 0:
-            return None
-        if 'input_ids' in result:
-            result['position_ids'] = [list(range(self.max_seqlen)) for _ in range(len(result['input_ids']))]
-        return result
+    def __call__(self, data: Optional[CPTMessage]) -> Optional[CPTConcatedMessage]:
+        if self.concated is None:
+            self.concated = {
+                'tokens': deque([[]]),
+                'channels': deque([[]]),
+                'index': deque([[0, 0]])
+            }
+        if data is not None:
+            batch_tokens = data.tokens
+            batch_channels = data.channels
+            for b in range(len(batch_tokens)):
+                tokens = batch_tokens[b]
+                channel = batch_channels[b]
+                # concated to max_seqlen+1 because input_ids and labels are obtained by tokens[:-1] and tokens[1:]
+                while len(self.concated['tokens'][-1]) + len(tokens) > self.max_seqlen + 1:
+                    cutted_len = self.max_seqlen + 1 - len(self.concated['tokens'][-1])
+                    last_index = self.concated['index'][-1][1]
+                    self.concated['index'].append([last_index, last_index])
+                    if cutted_len == 0:
+                        self.concated['tokens'].append([])
+                        self.concated['channels'].append([])
+                        continue
+                    self.concated['tokens'][-1].extend(tokens[:cutted_len])
+                    self.concated['channels'][-1].append((channel, cutted_len-1))
+                    tokens = tokens[cutted_len-1:]
+                    self.concated['tokens'].append([])
+                    self.concated['channels'].append([])
+                self.concated['tokens'][-1].extend(tokens)
+                self.concated['channels'][-1].append((channel, len(tokens)))
+                self.concated['index'][-1][1] += 1
+        if len(self.concated['tokens']) > self.batch_size:
+            concated_message = CPTConcatedMessage(result=[], channels=[], length=0)
+            begin_index, _ = self.concated['index'][0]
+            for _ in range(self.batch_size):
+                concated_message.result.append(self.concated['tokens'].popleft())
+                concated_message.channels.append(self.concated['channels'].popleft())
+                _, end_index = self.concated['index'].popleft()
+            concated_message.length = end_index - begin_index
+            return concated_message
+        return None
 
 @dataclass
 class SFTConcatFn:
     batch_size: int
     max_seqlen: int
     pad_token_id: int
+    concated: Optional[Dict[str, Deque]] = None
 
-    def __call__(self, data_concating: Dict[str, List[Any]], data: Dict[str, List[Any]]):
-        data_validation(data)
-        result = {}
-        for key in data:
-            assert key in ("input_ids", "labels", "position_ids")
-            value = data[key]
-            bs = len(value)
-            for b in range(bs):
-                if len(data_concating[key]) == 0:
-                    data_concating[key].append([])
-                prev_seqs = data_concating[key][-1]
-                prev_seqlen = len(prev_seqs)
-                seqlen = len(value[b])
-                if seqlen > self.max_seqlen:
-                    continue
-                elif prev_seqlen + seqlen > self.max_seqlen:
-                    if key in ("input_ids", "labels"):
-                        pad = self.pad_token_id
-                    else:
-                        pad = 0
-                    prev_seqs.extend([pad,]*(self.max_seqlen-len(prev_seqs)))
-                    data_concating[key].append(value[b])
+    def __call__(self, data: Optional[SFTMessage]) -> Optional[SFTConcatedMessage]:
+        if self.concated is None:
+            self.concated = {
+                'input_ids': deque([[]]),
+                'labels': deque([[]]),
+                'channels': deque([[]]),
+                'index': deque([[0, 0]])
+            }
+        if data is not None:
+            assert len(data.input_ids) == len(data.labels), f"batchsize not match, input_ids: {len(data.input_ids)} - labels: {len(data.labels)}"
+            for b in range(len(data.input_ids)):
+                input_ids = data.input_ids[b]
+                labels = data.labels[b]
+                channel = data.channels[b]
+                assert len(input_ids) == len(labels), f"seqlen not match, input_ids: {len(input_ids)} - labels: {len(labels)}"
+                if len(self.concated['input_ids'][-1]) + len(input_ids) > self.max_seqlen:
+                    if len(input_ids) > self.max_seqlen:
+                        continue
+                    concated_len = len(self.concated['input_ids'][-1])
+                    self.concated['input_ids'][-1].extend([self.pad_token_id] * (self.max_seqlen - concated_len))
+                    self.concated['labels'][-1].extend([-100] * (self.max_seqlen - concated_len))
+                    self.concated['input_ids'].append(input_ids)
+                    self.concated['labels'].append(labels)
+                    self.concated['channels'].append([(channel, len(input_ids))])
+                    last_index = self.concated['index'][-1][1]
+                    self.concated['index'].append([last_index+1, last_index+1])
                 else:
-                    prev_seqs.extend(value[b])
-            concated_bs = len(data_concating[key])
-            if concated_bs > self.batch_size:
-                result[key] = data_concating[key][:self.batch_size]
-                data_concating[key] = data_concating[key][self.batch_size:]
-        if len(result) == 0:
-            return None
-        return result
+                    self.concated['input_ids'][-1].extend(input_ids)
+                    self.concated['labels'][-1].extend(labels)
+                    self.concated['channels'][-1].append((channel, len(input_ids)))
+                    self.concated['index'][-1][1] += 1
+        if len(self.concated['input_ids']) > self.batch_size:
+            concated_message = SFTConcatedMessage(result=[], channels=[], length=0)
+            begin_index, _ = self.concated['index'][0]
+            for _ in range(self.batch_size):
+                input_ids = self.concated['input_ids'].popleft()
+                labels = self.concated['labels'].popleft()
+                channels = self.concated['channels'].popleft()
+                concated_message.result.append(input_ids+labels)
+                concated_message.channels.append(channels)
+                _, last_index = self.concated['index'].popleft()
+            concated_message.length = last_index-begin_index
+            return concated_message
+        return None 

--- a/megatron_patch/template/helper.py
+++ b/megatron_patch/template/helper.py
@@ -24,7 +24,6 @@ from megatron.training import get_args, get_timers
 from megatron.training.utils import (
     average_losses_across_data_parallel_group,
     get_batch_on_this_cp_rank,
-    get_batch_on_this_tp_rank,
 )
 
 from megatron.core.models.gpt import GPTModel
@@ -32,10 +31,10 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron_patch.data.utils import (
     get_batch_on_this_tp_rank_original,
     get_batch_on_this_tp_rank_idxmap_sft,
-    get_batch_on_this_tp_rank_online_packing,
+    get_batch_on_this_tp_rank,
     get_position_id_on_this_tp_rank_idxmap_sft_packing
 )
-
+from typing import List, Tuple, Optional
 def get_batch(data_iterator):
     """Generate a batch."""
     args = get_args()
@@ -66,20 +65,6 @@ def get_batch(data_iterator):
 
         return None, None, None, None, None, None, packed_seq_params
 
-    if args.online_packing:
-        batch = get_batch_on_this_tp_rank_online_packing(data_iterator)
-        num_seqs = batch.pop('num_seqs')
-        # slice batch along sequence dimension for context parallelism
-        batch = get_batch_on_this_cp_rank(batch)
-        return (
-            batch['tokens'],
-            batch['labels'],
-            batch['loss_mask'],
-            batch['attention_mask'],
-            batch['position_ids'],
-            num_seqs,
-            None
-        )
     if args.dataset == 'JSON-SFT':
         if args.train_mode == "pretrain":
             raise ValueError('The JSON-SFT dataset should only be used for finetuning!')
@@ -98,13 +83,12 @@ def get_batch(data_iterator):
             num_seqs,
             None
         )
-    elif args.dataset == 'MMAP':
+    elif args.dataset == 'MMAP' or args.online_packing:
         # get batches based on the TP rank you are on
         if args.train_mode == "pretrain":
             batch = get_batch_on_this_tp_rank(data_iterator)
         else:
             batch = get_batch_on_this_tp_rank_idxmap_sft(data_iterator, per_seq_average=True)
-
         packed_seq_params = None
         if args.reset_position_ids:
             # sequence-packing, build cu_seqlens
@@ -136,7 +120,6 @@ def get_batch(data_iterator):
         # slice batch along sequence dimension for context parallelism
         num_seqs = batch.pop('num_seqs', None)
         batch = get_batch_on_this_cp_rank(batch)
-
         return (
             batch['tokens'],
             batch['labels'],
@@ -161,7 +144,6 @@ def loss_func(loss_mask: torch.Tensor, num_seqs: torch.Tensor, output_tensor: to
 
     losses = output_tensor.float()
     loss_mask = loss_mask.view(-1).float()
-
     # NOTE: for each seq, sum(loss_mask) == 1 if num_seqs is not None,
     # otherwise sum(loss_mask) == n_tokens
     loss = torch.stack([torch.sum(losses.view(-1) * loss_mask), loss_mask.sum()])
@@ -182,11 +164,168 @@ def loss_func(loss_mask: torch.Tensor, num_seqs: torch.Tensor, output_tensor: to
     # NOTE: The grad will be scaled down by CP size later, should not remove this multilication factor
     # LINK: https://github.com/NVIDIA/Megatron-LM/issues/906
     # The issue is solved since 0926
-
     if num_seqs is None:
         # average on token-level
         return loss[0] / loss[1] * args.context_parallel_size, {"lm loss": averaged_loss}
     return loss[0] * args.context_parallel_size, num_seqs.sum(), {"lm loss": averaged_loss}
+
+def get_batch_with_channel(data_iterator):
+    """Generate a batch."""
+    args = get_args()
+
+    # TODO: this is pretty hacky, find a better way
+    if (not mpu.is_pipeline_first_stage()) and (not mpu.is_pipeline_last_stage()):
+        packed_seq_params = None
+        if args.dataset == 'MMAP' and args.train_mode == "finetune" and args.reset_position_ids:
+            position_ids = get_position_id_on_this_tp_rank_idxmap_sft_packing(data_iterator)
+            position_ids = position_ids[0] # shape: [seq_length]
+            start_indices = (position_ids == 0).nonzero(as_tuple=True)[0]
+            seqlens = start_indices[1:] - start_indices[:-1]
+            # NOTE: cu_seqlens: [0, A1, A1+A2, A1+A2+A3, ..., seq_len]
+            if seqlens.shape != torch.Size([0]):
+                cu_seqlens = torch.zeros(start_indices.shape[0] + 1, device="cpu", dtype=torch.int)
+                cu_seqlens[1:-1] = torch.cumsum(seqlens, dim=0)
+                cu_seqlens[-1] = position_ids.shape[0]
+                max_seqlen = torch.max(seqlens.max(), position_ids.max() + 1)
+                packed_seq_params = PackedSeqParams(
+                    cu_seqlens_q=cu_seqlens,
+                    cu_seqlens_kv=cu_seqlens,
+                    qkv_format='thd',
+                    max_seqlen_q = max_seqlen,
+                    max_seqlen_kv = max_seqlen,
+                )
+            else:
+                packed_seq_params = None
+
+        return None, None, None, None, None, None, packed_seq_params, None
+
+    if args.dataset == 'MMAP' or args.online_packing:
+        # get batches based on the TP rank you are on
+        if args.train_mode == "pretrain":
+            batch = get_batch_on_this_tp_rank(data_iterator)
+        else:
+            batch = get_batch_on_this_tp_rank_idxmap_sft(data_iterator, per_seq_average=True)
+        packed_seq_params = None
+        if args.reset_position_ids:
+            # sequence-packing, build cu_seqlens
+            position_ids = batch.get('position_ids', None)
+            if position_ids is not None:
+                # mbs = 1
+                position_ids = position_ids[0] # shape: [seq_length]
+                start_indices = (position_ids == 0).nonzero(as_tuple=True)[0]
+                seqlens = start_indices[1:] - start_indices[:-1]
+                if seqlens.shape != torch.Size([0]):
+                    # NOTE: cu_seqlens: [0, A1, A1+A2, A1+A2+A3, ..., seq_len]
+                    # cu_seqlens = torch.zeros(start_indices.shape[0] + 1, device=position_ids.device, dtype=torch.int)
+                    cu_seqlens = torch.zeros(start_indices.shape[0] + 1, device="cpu", dtype=torch.int)
+                    cu_seqlens[1:-1] = torch.cumsum(seqlens, dim=0)
+                    cu_seqlens[-1] = position_ids.shape[0]
+                    max_seqlen = torch.max(seqlens.max(), position_ids.max() + 1)
+                    packed_seq_params = PackedSeqParams(
+                        cu_seqlens_q=cu_seqlens,
+                        cu_seqlens_kv=cu_seqlens,
+                        qkv_format='thd',
+                        max_seqlen_q = max_seqlen,
+                        max_seqlen_kv = max_seqlen,
+                    )
+                else:
+                    packed_seq_params = None
+
+        if packed_seq_params is not None and args.context_parallel_size > 1:
+            raise ValueError('Sequence Packing is not supported when CP>1 !')
+        # slice batch along sequence dimension for context parallelism
+        num_seqs = batch.pop('num_seqs', None)
+        batch = get_batch_on_this_cp_rank(batch)
+        channels = batch.get('channels')
+        return (
+            batch['tokens'],
+            batch['labels'],
+            batch['loss_mask'],
+            batch['attention_mask'],
+            batch['position_ids'],
+            num_seqs,
+            packed_seq_params,
+            channels
+        )
+    else:
+        raise ValueError("please set correct --dataset ")
+
+
+def loss_func_with_channel(loss_mask: torch.Tensor, num_seqs: torch.Tensor, channels: Optional[List[Tuple[str, int]]], output_tensor: torch.Tensor):
+    """Loss function.
+
+    Args:
+        loss_mask (torch.Tensor): Used to mask out some portions of the loss
+        output_tensor (torch.Tensor): The tensor with the losses
+    """
+    @torch.no_grad()
+    def calc_channel_loss(masked_loss, channels):
+        flattened_channels = [channel for batch_channel in channels for channel in batch_channel]
+        channel_set = list(set([x[0] for x in flattened_channels]))
+        channel_mask = torch.zeros([len(channel_set), masked_loss.shape[0]], device=masked_loss.device)
+        end_index = 0
+        for channel, length in flattened_channels:
+            channel_idx = channel_set.index(channel)
+            begin_index = end_index
+            end_index += length
+            channel_mask[channel_idx, begin_index: end_index] = 1
+        channel_masked_loss = masked_loss * channel_mask
+        channel_loss = torch.stack([torch.sum(channel_masked_loss, dim=1), channel_mask.sum(dim=1)]).clone().detach()
+        gathered_channel = [None for _ in range(mpu.get_data_parallel_world_size())]
+        torch.distributed.all_gather_object(gathered_channel, channel_set, group=mpu.get_data_parallel_group())
+        gathered_channel_loss = [None for _ in range(mpu.get_data_parallel_world_size())]
+        for i in range(len(gathered_channel_loss)):
+            gathered_channel_loss[i] = torch.empty([2, len(gathered_channel[i])], device=masked_loss.device)
+        torch.distributed.all_gather(gathered_channel_loss, channel_loss, group=mpu.get_data_parallel_group())
+        channel_loss_dict = {}
+        for rank in range(len(gathered_channel)):
+            channel_list = gathered_channel[rank]
+            for i in range(len(channel_list)):
+                channel = channel_list[i]
+                if channel not in channel_loss_dict:
+                    channel_loss_dict[f"{channel}_loss"] = gathered_channel_loss[rank][:, i]
+                else:
+                    channel_loss_dict[f"{channel}_loss"] += gathered_channel_loss[rank][:, i]
+        for channel_key, channel_value in channel_loss_dict.items():
+            channel_loss_dict[channel_key] = channel_value.tolist()
+        return channel_loss_dict
+
+    args = get_args()
+
+    losses = output_tensor.float()
+    loss_mask = loss_mask.view(-1).float()
+
+    # NOTE: for each seq, sum(loss_mask) == 1 if num_seqs is not None,
+    # otherwise sum(loss_mask) == n_tokens
+    masked_loss = losses.view(-1) * loss_mask
+    loss = torch.stack([torch.sum(masked_loss), loss_mask.sum()])
+    channel_loss_dict = {}
+    if channels is not None:
+        channel_loss_dict = calc_channel_loss(masked_loss.detach(), channels)
+    if args.context_parallel_size > 1:
+        # torch.distributed.all_reduce(loss, group=mpu.get_context_parallel_group())
+        raise Exception('channel_loss not support cp currently')
+
+    # Check individual rank losses are not NaN prior to DP all-reduce.
+    if args.check_for_nan_in_loss_and_grad:
+        global_rank = torch.distributed.get_rank()
+        assert not loss.isnan().any(), (
+            f"Rank {global_rank}: found NaN in local forward loss calculation. "
+            f"Device: {torch.cuda.current_device()}, node: {os.uname()[1]}"
+        )
+
+    averaged_loss = average_losses_across_data_parallel_group(loss)
+    averaged_loss = averaged_loss[0] / averaged_loss[1]
+
+    # NOTE: The grad will be scaled down by CP size later, should not remove this multilication factor
+    # LINK: https://github.com/NVIDIA/Megatron-LM/issues/906
+    # The issue is solved since 0926
+    loss_dict = {"lm_loss": averaged_loss.item()}
+    loss_dict.update(channel_loss_dict)
+    if num_seqs is None:
+        # average on token-level
+        return loss[0] / loss[1] * args.context_parallel_size, loss_dict
+    return loss[0] * args.context_parallel_size, num_seqs.sum(), loss_dict
 
 def forward_step(data_iterator, model):
     """Forward training step.
@@ -196,16 +335,21 @@ def forward_step(data_iterator, model):
         model (GPTModel): The GPT Model
     """
     timers = get_timers()
-    args = get_args()
-
     # Get the batch.
     timers("batch-generator", log_level=2).start()
-    tokens, labels, loss_mask, attention_mask, position_ids, num_seqs, packed_seq_params = get_batch(data_iterator)
+    args = get_args()
+    if args.calc_channel_loss:
+        tokens, labels, loss_mask, attention_mask, position_ids, num_seqs, packed_seq_params, channels = get_batch_with_channel(data_iterator)
+    else:
+        tokens, labels, loss_mask, attention_mask, position_ids, num_seqs, packed_seq_params = get_batch(data_iterator)
     timers("batch-generator").stop()
     if 'loss_mask' in inspect.signature(GPTModel.forward).parameters:
         # NOTE: MTP-head (since 0328) requires loss_mask to compute correct loss scale.
         output_tensor = model(tokens, position_ids, attention_mask, labels=labels, packed_seq_params=packed_seq_params, loss_mask=loss_mask)
     else:
         output_tensor = model(tokens, position_ids, attention_mask, labels=labels, packed_seq_params=packed_seq_params)
-
-    return output_tensor, partial(loss_func, loss_mask, num_seqs)
+    if args.calc_channel_loss:
+        partial_loss_func = partial(loss_func_with_channel, loss_mask, num_seqs, channels)
+    else:
+        partial_loss_func = partial(loss_func, loss_mask, num_seqs)
+    return output_tensor, partial_loss_func

--- a/megatron_patch/training/training.py
+++ b/megatron_patch/training/training.py
@@ -16,25 +16,18 @@ import torch.distributed
 from megatron.training.log_handler import CustomHandler
 # Make default logging level INFO, but filter out all log messages not from MCore.
 logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
-from megatron.training.theoretical_memory_usage import report_theoretical_memory
 import time
 # The earliest we can measure the start time.
 _TRAIN_START_TIME = time.time()
 import torch
 
-from megatron.core import mpu, tensor_parallel
+from megatron.core import mpu
 from megatron.core.utils import (
     check_param_hashes_across_dp_replicas,
     get_model_config,
     StragglerDetector,
-    is_te_min_version,
 )
-from megatron.core.fp8_utils import correct_amax_history_if_needed
-from megatron.training.checkpointing import load_checkpoint
 from megatron.training.checkpointing import save_checkpoint
-from megatron.training.checkpointing import checkpoint_exists
-from megatron.core.transformer.module import Float16Module
-from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed import DistributedDataParallel as DDP
 from megatron.core.distributed.custom_fsdp import FullyShardedDataParallel as custom_FSDP
 try:
@@ -45,37 +38,18 @@ except ImportError:
     HAVE_FSDP2 = False
 
 from megatron.core.distributed import finalize_model_grads
-from megatron.core.enums import ModelType
-from megatron.core.optimizer import get_megatron_optimizer, OptimizerConfig
 from megatron.core.rerun_state_machine import (
     get_rerun_state_machine,
     destroy_rerun_state_machine,
     RerunDataIterator,
-    RerunMode,
 )
 from megatron.training.initialize import initialize_megatron
 from megatron.training.initialize import write_args_to_tensorboard
 from megatron.training.initialize import set_jit_fusion_options
-from megatron.training.utils import (
-    get_batch_on_this_cp_rank,
-    get_batch_on_this_tp_rank,
-)
 from megatron.legacy.data.data_samplers import build_pretraining_data_loader
-from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
-from megatron.core.transformer.moe import upcycling_utils
-from megatron.core.transformer.moe.moe_utils import track_moe_metrics
-from megatron.core.transformer.multi_token_prediction import MTPLossLoggingHelper
 from megatron.core.parallel_state import (
     destroy_global_memory_buffer,
     destroy_model_parallel,
-    get_amax_reduction_group,
-    model_parallel_is_initialized,
-)
-from megatron.core.pipeline_parallel import get_forward_backward_func
-from megatron.core.pipeline_parallel.schedules import (
-    convert_schedule_table_to_order,
-    get_pp_rank_microbatches,
-    get_schedule_table,
 )
 from megatron.core.num_microbatches_calculator import (
     destroy_num_microbatches_calculator,
@@ -88,20 +62,11 @@ from megatron.training.async_utils import maybe_finalize_async_save
 from megatron.training.utils import (
     append_to_progress_log,
     calc_params_l2_norm,
-    check_adlr_autoresume_termination,
-    logical_and_across_model_parallel_group,
-    reduce_max_stat_across_model_parallel_group,
-    is_last_rank,
     print_rank_0,
-    print_rank_last,
-    report_memory,
-    unwrap_model,
-    update_use_dist_ckpt,
 )
 from megatron.training.global_vars import (
     destroy_global_vars,
     get_args,
-    get_signal_handler,
     get_timers,
     get_tensorboard_writer,
     get_wandb_writer,
@@ -113,11 +78,20 @@ from megatron.training import ft_integration
 from megatron.training.training import (
     print_datetime,
     setup_model_and_optimizer,
-    train,
     preprocess_common_state_dict,
     evaluate_and_print_results,
     build_train_valid_test_datasets,
-    cyclic_iter
+    should_disable_forward_pre_hook,
+    disable_forward_pre_hook,
+    save_checkpoint_and_time,
+    dummy_train_step,
+    train_step,
+    enable_forward_pre_hook,
+    num_floating_point_operations,
+    post_training_step_callbacks,
+    checkpoint_and_decide_exit,
+    cyclic_iter,
+    training_log,
 )
 
 stimer = StragglerDetector()
@@ -206,13 +180,25 @@ def build_train_valid_test_data_iterators(
     # Build iterators.
     dl_type = args.dataloader_type
     assert dl_type in ['single', 'cyclic', 'external']
+    
+    class cyclic_wrapper:
+        def __init__(self, it):
+            self.iter = it
+            self.cyclic_iter = iter(cyclic_iter(self.iter))
+
+        def __next__(self):
+            return next(self.cyclic_iter)
+        
+        def __iter__(self):
+            return self
 
     def _get_iterator(dataloader_type, dataloader):
         """Return dataset iterator."""
         if dataloader_type == "single":
             return RerunDataIterator(iter(dataloader))
         elif dataloader_type == "cyclic":
-            return RerunDataIterator(iter(cyclic_iter(dataloader)))
+            return RerunDataIterator(cyclic_wrapper(dataloader))
+            # return RerunDataIterator(iter(cyclic_iter(dataloader)))
         elif dataloader_type == "external":
             # External dataloader is passed through. User is expected to define how to iterate.
             if isinstance(dataloader, list):
@@ -238,6 +224,367 @@ def build_train_valid_test_data_iterators(
         test_data_iterator = None
 
     return train_data_iterator, valid_data_iterator, test_data_iterator
+
+def train(forward_step_func, model, optimizer, opt_param_scheduler,
+          train_data_iterator, valid_data_iterator,
+          process_non_loss_data_func, config, checkpointing_context, non_loss_data_func):
+    """Training function: run train_step desired number of times, run validation, checkpoint."""
+    args = get_args()
+    timers = get_timers()
+    one_logger = get_one_logger()
+
+    if args.run_workload_inspector_server:
+        try:
+            from workload_inspector.utils.webserver import run_server
+            import threading
+            threading.Thread(target=run_server, daemon=True, args=(torch.distributed.get_rank(), )).start()
+        except ModuleNotFoundError:
+            print_rank_0("workload inspector module not found.")
+
+    # Write args to tensorboard
+    write_args_to_tensorboard()
+
+    # Turn on training mode which enables dropout.
+    for model_module in model:
+        model_module.train()
+
+    # Tracking loss.
+    total_loss_dict = {}
+
+    # Iterations.
+    iteration = args.iteration
+    # Make sure rerun_state_machine has the right iteration loaded from checkpoint.
+    rerun_state_machine = get_rerun_state_machine()
+    if rerun_state_machine.current_iteration != iteration:
+        print_rank_0(f"Setting rerun_state_machine.current_iteration to {iteration}...")
+        rerun_state_machine.current_iteration = iteration
+
+    # Track E2E metrics at the start of training.
+    one_logger_utils.on_train_start(iteration=iteration, consumed_train_samples=args.consumed_train_samples,
+                                    train_samples=args.train_samples, seq_length=args.seq_length,
+                                    train_iters=args.train_iters, save=args.save, async_save=args.async_save,
+                                    log_throughput=args.log_throughput,
+                                    num_floating_point_operations_so_far=args.num_floating_point_operations_so_far)
+
+    num_floating_point_operations_so_far = args.num_floating_point_operations_so_far
+
+    # Setup some training config params.
+    config.grad_scale_func = optimizer.scale_loss
+    config.timers = timers
+    if isinstance(model[0], (custom_FSDP, DDP)) and args.overlap_grad_reduce:
+        assert config.no_sync_func is None, \
+            ('When overlap_grad_reduce is True, config.no_sync_func must be None; '
+             'a custom no_sync_func is not supported when overlapping grad-reduce')
+        config.no_sync_func = [model_chunk.no_sync for model_chunk in model]
+        if len(model) == 1:
+            config.no_sync_func = config.no_sync_func[0]
+        if args.align_grad_reduce:
+            config.grad_sync_func = [model_chunk.start_grad_sync for model_chunk in model]
+            if len(model) == 1:
+                config.grad_sync_func = config.grad_sync_func[0]
+    if args.overlap_param_gather and args.align_param_gather:
+        config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
+        if len(model) == 1:
+            config.param_sync_func = config.param_sync_func[0]
+    config.finalize_model_grads_func = finalize_model_grads
+
+    timers('interval-time', log_level=0).start(barrier=True)
+    print_datetime('before the start of training step')
+    report_memory_flag = True
+    pre_hook_enabled = False
+    should_exit = False
+    exit_code = 0
+
+    if args.manual_gc:
+        # Disable the default garbage collector and perform the collection manually.
+        # This is to align the timing of garbage collection across ranks.
+        assert args.manual_gc_interval >= 0, \
+            'Manual garbage collection interval should be larger than or equal to 0'
+        gc.disable()
+        gc.collect()
+
+    # Singleton initialization of straggler detector.
+    if args.log_straggler:
+        global stimer
+        world = torch.distributed.get_world_size()
+        rank = torch.distributed.get_rank()
+        mmcnt = args.straggler_minmax_count
+        stimer.configure(world, rank,
+                mmcnt = mmcnt,
+                enabled = not args.disable_straggler_on_startup,
+                port = args.straggler_ctrlr_port)
+    num_floating_point_operations_since_last_log_event = 0.0
+
+    num_microbatches = get_num_microbatches()
+    eval_duration = 0.0
+    eval_iterations = 0
+
+    def get_e2e_base_metrics():
+        """Get base metrics values for one-logger to calculate E2E tracking metrics.
+        """
+        num_floating_point_operations_since_current_train_start = \
+            num_floating_point_operations_so_far - args.num_floating_point_operations_so_far
+        return {
+            'iteration': iteration,
+            'train_duration': timers('interval-time').active_time(),
+            'eval_duration': eval_duration,
+            'eval_iterations': eval_iterations,
+            'total_flops_since_current_train_start': num_floating_point_operations_since_current_train_start,
+            'num_floating_point_operations_so_far': num_floating_point_operations_so_far,
+            'consumed_train_samples': args.consumed_train_samples,
+            'world_size': args.world_size,
+            'seq_length': args.seq_length
+        }
+    # Cache into one-logger for callback.
+    if one_logger:
+        with one_logger.get_context_manager():
+            one_logger.store_set('get_e2e_base_metrics', get_e2e_base_metrics)
+
+    prof = None
+    if args.profile and torch.distributed.get_rank() in args.profile_ranks and args.use_pytorch_profiler:
+        prof = torch.profiler.profile(
+        schedule=torch.profiler.schedule(
+            wait=max(args.profile_step_start-1, 0),
+            warmup=1 if args.profile_step_start > 0 else 0,
+            active=args.profile_step_end-args.profile_step_start,
+            repeat=1),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(args.tensorboard_dir),
+        record_shapes=True,
+        with_stack=True)
+        prof.start()
+
+    start_iteration = iteration
+    # Disable forward pre-hook to start training to ensure that errors in checkpoint loading
+    # or random initialization don't propagate to all ranks in first all-gather (which is a
+    # no-op if things work correctly).
+    if should_disable_forward_pre_hook(args):
+        disable_forward_pre_hook(model, param_sync=False)
+        # Also remove param_sync_func temporarily so that sync calls made in
+        # `forward_backward_func` are no-ops.
+        param_sync_func = config.param_sync_func
+        config.param_sync_func = None
+        pre_hook_enabled = False
+    # Also, check weight hash across DP replicas to be very pedantic.
+    if args.check_weight_hash_across_dp_replicas_interval is not None:
+        assert check_param_hashes_across_dp_replicas(model, cross_check=True), \
+            "Parameter hashes not matching across DP replicas"
+        torch.distributed.barrier()
+        print_rank_0(f">>> Weight hashes match after {iteration} iterations...")
+
+    # Run training iterations till done.
+    def finish_train(args, iteration):
+        if args.online_packing:
+            return args.consumed_train_samples >= args.train_samples
+        return iteration >= args.train_iters
+    while not finish_train(args, iteration):
+        if args.profile and torch.distributed.get_rank() in args.profile_ranks:
+            if args.use_pytorch_profiler:
+                prof.step()
+            elif iteration == args.profile_step_start:
+                torch.cuda.cudart().cudaProfilerStart()
+                torch.autograd.profiler.emit_nvtx(record_shapes=True).__enter__()
+
+        ft_integration.on_checkpointing_start()
+        maybe_finalize_async_save(blocking=False)
+        ft_integration.on_checkpointing_end(is_async_finalization=True)
+
+        # Update number of microbatches first without consistency check to decide if a
+        # checkpoint should be saved. If the number of microbatches is different
+        # from the previous iteration, save a checkpoint. Then run consistency check
+        # to make sure training configuration is still valid.
+        update_num_microbatches(args.consumed_train_samples, consistency_check=False, verbose=True)
+        if get_num_microbatches() != num_microbatches and iteration != 0:
+            assert get_num_microbatches() > num_microbatches, \
+                (f"Number of microbatches should be increasing due to batch size rampup; "
+                 f"instead going from {num_microbatches} to {get_num_microbatches()}")
+            if args.save is not None:
+                save_checkpoint_and_time(iteration, model, optimizer,
+                                         opt_param_scheduler,
+                                         num_floating_point_operations_so_far,
+                                         checkpointing_context, train_data_iterator=train_data_iterator)
+        num_microbatches = get_num_microbatches()
+        update_num_microbatches(args.consumed_train_samples, consistency_check=True, verbose=True)
+
+        # Completely skip iteration if needed.
+        if iteration in args.iterations_to_skip:
+            # Dummy train_step to fast forward train_data_iterator.
+            dummy_train_step(train_data_iterator)
+            iteration += 1
+            batch_size = mpu.get_data_parallel_world_size() * \
+                         args.micro_batch_size * \
+                         get_num_microbatches()
+            args.consumed_train_samples += batch_size
+            args.skipped_train_samples += batch_size
+            continue
+
+        # Run training step.
+        args.curr_iteration = iteration
+        ft_integration.on_training_step_start()
+        try:
+            loss_dict, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad = \
+                train_step(forward_step_func,
+                           train_data_iterator,
+                           model,
+                           optimizer,
+                           opt_param_scheduler,
+                           config)
+            if args.calc_channel_loss:
+                gathered_loss = [None for _ in range(torch.distributed.get_world_size())]
+                torch.distributed.all_gather_object(gathered_loss, loss_dict)
+                merged_loss_dict = {}
+                for loss_dict in gathered_loss:
+                    merged_loss_dict.update(loss_dict)
+                loss_dict = merged_loss_dict
+        except StopIteration:
+            loss_dict, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad = {}, True, True, True, 0, None, None
+            
+        ft_integration.on_training_step_end()
+        if should_checkpoint:
+            save_checkpoint_and_time(iteration, model, optimizer,
+                                     opt_param_scheduler,
+                                     num_floating_point_operations_so_far,
+                                     checkpointing_context, train_data_iterator=train_data_iterator)
+        if should_exit:
+            break
+
+        # Enable forward pre-hooks after first set of forward and backward passes.
+        # When running in fp16, skip all NaN iterations until steady-state loss scaling value
+        # is reached.
+        if iteration == start_iteration:
+            if skipped_iter:
+                # Only enable forward pre-hook after a training step has successfully run. Relevant
+                # for fp16 codepath where first XX iterations are skipped until steady-state loss
+                # scale value is reached.
+                start_iteration = iteration + 1
+            else:
+                # Enable forward pre-hook after training step has successfully run. All subsequent
+                # forward passes will use the forward pre-hook / `param_sync_func` in
+                # `forward_backward_func`.
+                if should_disable_forward_pre_hook(args):
+                    enable_forward_pre_hook(model)
+                    config.param_sync_func = param_sync_func
+                    pre_hook_enabled = True
+
+        iteration += 1
+        batch_size = mpu.get_data_parallel_world_size() * \
+                     args.micro_batch_size * \
+                     get_num_microbatches()
+        if args.online_packing:
+            consumed_samples = 0
+            if mpu.get_data_parallel_src_rank() == 0:
+                if args.dataloader_type == 'cyclic':
+                    consumed_samples = train_data_iterator.iterable.iter._iterator.consumed_samples
+                else:
+                    consumed_samples = train_data_iterator.iterable.consumed_samples
+            consumed_samples = torch.tensor(consumed_samples, device=torch.cuda.current_device())
+            torch.distributed.all_reduce(consumed_samples)
+            args.consumed_train_samples = consumed_samples.item()
+        else:
+            args.consumed_train_samples += batch_size
+        num_skipped_samples_in_batch = (get_current_global_batch_size() -
+                                        get_current_running_global_batch_size())
+        if args.decrease_batch_size_if_needed:
+            assert num_skipped_samples_in_batch >= 0
+        else:
+            assert num_skipped_samples_in_batch == 0
+        args.skipped_train_samples += num_skipped_samples_in_batch
+        num_floating_point_operations_in_batch = num_floating_point_operations(args, batch_size)
+        num_floating_point_operations_so_far += num_floating_point_operations_in_batch
+        num_floating_point_operations_since_last_log_event += num_floating_point_operations_in_batch
+
+        # Logging.
+        if not optimizer.is_stub_optimizer:
+            loss_scale = optimizer.get_loss_scale().item()
+        else:
+            loss_scale = 1.0
+        params_norm = None
+
+        if args.log_params_norm:
+            params_norm = calc_params_l2_norm(model)
+        learning_rate = None
+        decoupled_learning_rate = None
+        for param_group in optimizer.param_groups:
+            if param_group['is_decoupled_lr']:
+                decoupled_learning_rate = param_group['lr']
+            else:
+                learning_rate = param_group['lr']
+        report_memory_flag = training_log(loss_dict, total_loss_dict,
+                                          learning_rate,
+                                          decoupled_learning_rate,
+                                          iteration, loss_scale,
+                                          report_memory_flag, skipped_iter,
+                                          grad_norm, params_norm, num_zeros_in_grad)
+
+        # Evaluation.
+        if args.eval_interval and iteration % args.eval_interval == 0 and \
+            args.do_valid:
+            timers('interval-time').stop()
+            if should_disable_forward_pre_hook(args):
+                disable_forward_pre_hook(model)
+                pre_hook_enabled = False
+            if args.manual_gc and args.manual_gc_eval:
+                # Collect all objects.
+                gc.collect()
+            prefix = f'iteration {iteration}'
+            timers('eval-time', log_level=0).start(barrier=True)
+            evaluate_and_print_results(prefix, forward_step_func,
+                                       valid_data_iterator, model,
+                                       iteration, process_non_loss_data_func,
+                                       config, verbose=False, write_to_tensorboard=True,
+                                       non_loss_data_func=non_loss_data_func)
+            eval_duration += timers('eval-time').elapsed()
+            eval_iterations += args.eval_iters
+            timers('eval-time').stop()
+            one_logger_utils.track_e2e_metrics()
+
+            if args.manual_gc and args.manual_gc_eval:
+                # Collect only the objects created and used in evaluation.
+                gc.collect(generation=0)
+            if should_disable_forward_pre_hook(args):
+                enable_forward_pre_hook(model)
+                pre_hook_enabled = True
+            timers('interval-time', log_level=0).start(barrier=True)
+
+        # Miscellaneous post-training-step functions (e.g., FT heartbeats, GC).
+        # Some of these only happen at specific iterations.
+        post_training_step_callbacks(model, optimizer, opt_param_scheduler, iteration, prof,
+                                     num_floating_point_operations_since_last_log_event)
+
+        # Checkpoint and decide whether to exit.
+        should_exit = checkpoint_and_decide_exit(model, optimizer, opt_param_scheduler, iteration,
+                                                 num_floating_point_operations_so_far,
+                                                 checkpointing_context, train_data_iterator)
+        if should_exit:
+            break
+
+    one_logger_utils.track_e2e_metrics()
+
+    # Flush TensorBoard, WandB writers and one-logger.
+    writer = get_tensorboard_writer()
+    if writer:
+        writer.flush()
+
+    # Close out pre-hooks if using distributed optimizer and overlapped param gather.
+    if pre_hook_enabled:
+        disable_forward_pre_hook(model)
+
+    ft_integration.on_checkpointing_start()
+    # This will finalize all unfinalized async request and terminate
+    # a persistent async worker if persistent ckpt worker is enabled
+    maybe_finalize_async_save(blocking=True, terminate=True)
+    ft_integration.on_checkpointing_end(is_async_finalization=True)
+    if args.enable_ft_package and ft_integration.get_rank_monitor_client() is not None:
+        ft_integration.get_rank_monitor_client().shutdown_workload_monitoring()
+
+    # If any exit conditions (signal handler, duration, iterations) have been reached, exit.
+    if should_exit:
+        wandb_writer = get_wandb_writer()
+        if wandb_writer:
+            wandb_writer.finish()
+        ft_integration.shutdown()
+        sys.exit(exit_code)
+
+    return iteration, num_floating_point_operations_so_far
 
 def pretrain(
     train_valid_test_dataset_provider,


### PR DESCRIPTION
add_feat:
1. cpt 增加channel_loss逻辑  
2. 修复online_packing逻辑

channel_loss逻辑：
1. 从dataloader获取每个document的channel， 在packing时按如下方式记录：(channel1, length), (channel2, length), ...  （这么做的原因是考虑到从多进程队列里取数据的时间相对较慢，channel的信息存储在队列里尽量精简，减少取数据的时间）
2. dataloader只会在tp_rank=0时做iteration，从性能考虑，channel信息不做不必要的广播，仅会在tp_rank0计算channel_loss
3. 计算channel_loss的逻辑, 根据每个channel的length，获取每个token的channel, 先在当前dp_group内将所有token按channel做聚合，计算loss以及每个channel的token数，再将聚合后的loss和每个channel的token数分发到所有的dp_group, 再做一遍聚合
4. 目前channel_loss不支持cp (cp需要把channel信息提前分发到每个cp rank)
5. 由于channel信息仅在tp_rank=0时获取和计算，因此最后的打印loss信息从print_rank_last改成了print_rank_0

online_packing逻辑：
1. dataloader继承torch.dataloader的多进程iterator逻辑, 在worker里执行tokenize和packing逻辑，其中tokenize在collator里实现，执行单条document->tokens, labels等字段的映射，packing逻辑在concator里实现，执行多条样本拼接的逻辑，这些逻辑可以在collator和concator里用户自定义实现
2. 无法直接复用原生dataloader iterator的原因：dataloader里有两个核心的队列：index_queue和data_queue, 原生的dataloader在worker里循环执行从index_queue里读取index，执行collator逻辑，结果放入data_queue, 在每次iterator取完数据后，执行put_index操作，将index存入index_queue; 而在online_packing逻辑中，在后台worker循环里除了要执行collator，还要执行concator逻辑，只有concat完以后才会放在data_queue队列里; 其次，由于拼接的数据量不固定，无法预估每次取完数据后下一次要放入多少index，因此index_queue也在一个后台进程里循环放入index, 只要index_queue里被worker进程消费了，就继续往后补
3. 为了方便日后扩展，concator和collator定义了统一的输入输出数据格式，放在types下，dataloader worker处理标准的格式
4. concator除了需要pack数据以外，还需要记录当前数据pack了多少条数据（CPTConcatedMessage.length）传给dataloader, 训练以此来累计consumed_samples而不是iteration*global_batch_size来处理，在online_packing模式下，以consumed_samples达到阈值作为训练终止条件

cpt训练截图如下：
<img width="2531" height="532" alt="image" src="https://github.com/user-attachments/assets/55f6e00b-afbf-4dd6-9fe8-a23ae19f1148" />

